### PR TITLE
Minor fixes to man page and interval description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ obj
 tags
 iwatch
 iwatch.so
+iwatch_test
 iwatch-*.tar.gz
 iwatch.cat1
 iwatch.html1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*.swp
 *.manlint
 *.o
 *~
@@ -11,7 +12,8 @@ config.status
 configure.in
 obj
 tags
-watch
-watch-*.tar.gz
-watch.cat1
-watch.html1
+iwatch
+iwatch.so
+iwatch-*.tar.gz
+iwatch.cat1
+iwatch.html1

--- a/iwatch.1
+++ b/iwatch.1
@@ -133,8 +133,8 @@ Toggle reversing the changing words.
 Toggle current reversing mode.
 .It Ic i
 Set the interval to the prefix number seconds.
-.It Ic i
-Toggle the pausing update output.
+.It Ic p
+Toggle the pausing of update output.
 .It Ic ?
 Show help message.
 .It Ic q

--- a/iwatch.c
+++ b/iwatch.c
@@ -283,7 +283,7 @@ display(BUFFER * cur, BUFFER * prev, reverse_mode_t reverse)
 	else if (opt_interval > 1)
 		printw("on every %d seconds", opt_interval);
 	else
-		printw("on every seconds");
+		printw("on every second");
 
 	ct = ctime(&lastupdate);
 	ct[24] = '\0';


### PR DESCRIPTION
Hello,

I came across watch and quite like the interactive approach it uses.

I realised that the man page referenced "i" instead of "p" for pausing. Please see the fix to iwatch.1 below.

When using an interval of 1, the description should be "on every second" instead of "on every seconds" (plural).

I am afraid I do not know how to create a pull request for an individual change, so I hope you don't mind the mix of things and inclusion of my .gitignore file.

Thanks for iwatch,
Preben Guldberg
